### PR TITLE
hazelcast config file changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The plugin for Hazelcast fetches nodes belonging to a given service from the Con
 
 **Currently works from Hazelcast 3.6-EA !**
 
-In order to get this plugin running, you must place the JAR on the classpath along with this above build of Hazelcast. Then you must alter the cluster.xml like this:
+In order to get this plugin running, you must place the JAR on the classpath along with this above build of Hazelcast. Then you must alter the hazelcast.xml like this:
 
  ```
  <join>


### PR DESCRIPTION
hazelcast.xml is a default configuration file. I believe it's appropriate to use default file names in examples.
